### PR TITLE
Feature/initial stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,223 @@ To run the tests:
 ```bash
 yarn test
 ```
+
+## Concepts
+
+`directo` is structured as a parser for English imperative sentences. All commands must start with a `verb`. Recognized command structures are:
+
+- `verb`
+  - login
+  - exit
+- `verb object`
+  - go north
+  - buy sword
+  - get lamp
+- `verb preposition object`
+  - sit on the log
+- `verb object preposition subject`
+  - give sword to steve
+- `verb determiner object`
+  - eat the berries _Many of these are likely the same as `verb object`, but quantifiers make a difference here._
+- `verb subject determiner object`
+  - give steve the sword
+  - give steve a mushroom
+
+When using `directo`, commands are declared based on the set of verbs and command structure they accept. Many command implementations will want to handle multiple structures (see the two ways one could give a sword to steve above).
+
+## Usage
+
+Using `directo` is as simple as registering commands and handlers:
+
+```javascript
+const { command, processText, Format, CommandResult } = require('directo');
+
+command({
+  verb: 'go',
+  func: async ({ format, object }) => {
+    if (format !== Format.VO) {
+      console.log('Go where?');
+      return CommandResult.FORMAT_ERROR;
+    }
+
+    console.log(`Okay, I went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+(async (commands) => {
+  for (const command of commands) {
+    await processText(command);
+  }
+})([
+  'go north',
+  'go south',
+  'go'
+]);
+```
+
+Prints:
+
+```none
+Okay, I went north
+Okay, I went south
+Go where?
+```
+
+In the above example, one could simplify the callback by specifying the `accept` field, at the cost of custom format error handling:
+
+```javascript
+const { command, processText, Format, CommandResult } = require('directo');
+
+command({
+  verb: 'go',
+  accept: [ Format.VO ],
+  func: async ({ object }) => {
+    console.log(`Okay, I went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+(async (commands) => {
+  for (const command of commands) {
+    const result = await processText(command);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log(`Did not understand '${command}'`);
+    }
+  }
+})([
+  'go north',
+  'go south',
+  'go',
+  'go bob the mushroom'
+]);
+```
+
+Prints
+
+```none
+Okay, I went north
+Okay, I went south
+Did not understand 'go'
+Did not understand 'go bob the mushroom'
+```
+
+The `verb` may aslo be specified as an array:
+
+```javascript
+command({
+  verb: ['go', 'move', 'walk'],
+  accept: [ Format.VO ],
+  func: async ({ format, object }) => {
+    console.log(`Okay, I went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+command({
+  verb: 'run',
+  func: async() => {
+    console.log('Slow it down, buddy!');
+
+    return CommandResult.HANDLED;
+  }
+});
+
+(async (commands) => {
+  for (const command of commands) {
+    const result = await processText(command);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log(`Did not understand '${command}'`);
+    }
+  }
+})([
+  'go north',
+  'move west',
+  'walk south',
+  'run east'
+]);
+```
+
+Prints
+
+```none
+Okay, I went north
+Okay, I went west
+Okay, I went south
+Slow it down, buddy!
+```
+
+## Instanced vs Singleton Directo
+
+The above examples use the top-level `processText` and `command` functions, which operate on an automatically-created singleton `Directo` instance. If you are so inclined, you may also instantiate and manage your own `Directo` instance:
+
+```javascript
+const { Directo, Format, CommandResult } = require('directo');
+
+const directo = new Directo();
+
+directo.addCommand({
+  verb: 'go',
+  func: async ({ format, object }) => {
+    if (format !== Format.VO) {
+      console.log('Go where?');
+      return CommandResult.FORMAT_ERROR;
+    }
+
+    console.log(`Okay, I went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+(async (commands) => {
+  for (const command of commands) {
+    await directo.processText(command);
+  }
+})([
+  'go north',
+  'go south',
+  'go'
+]);
+```
+
+## Process Context
+
+Since commands are defined ahead of time, rather than being in the I/O flow of the consuming application, there is an optional `context` argument in `processTest`. Anything passed in there will also be included as the `context` field of the object passed to command `func`s.
+
+```javascript
+const { Directo, Format, CommandResult } = require('directo');
+
+const directo = new Directo();
+
+directo.addCommand({
+  verb: 'go',
+  accept: [ Format.VO ],
+  func: async ({ format, object, context }) => {
+    console.log(`${context.name} went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+const gameContext = {
+  name: 'Bob'
+};
+
+(async (commands) => {
+  for (const command of commands) {
+    await directo.processText(command, gameContext);
+  }
+})([
+  'go west',
+]);
+```
+
+Prints
+
+```none
+Bob went west
+```

--- a/demo/demo1.js
+++ b/demo/demo1.js
@@ -1,0 +1,25 @@
+const { command, processText, Format, CommandResult } = require('../src');
+
+command({
+  verb: 'go',
+  accept: [ Format.VO ],
+  func: async ({ object }) => {
+    console.log(`Okay, I went ${object}`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+(async (commands) => {
+  for (const c of commands) {
+    const result = await processText(c);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log(`Did not understand '${c}'`);
+    }
+  }
+})([
+  'go north',
+  'go south',
+  'go',
+  'go bob the mushroom'
+]);

--- a/demo/demo2.js
+++ b/demo/demo2.js
@@ -1,0 +1,96 @@
+const { command, processText, Format, CommandResult } = require('../src');
+
+const readline = require('readline');
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout
+});
+
+const grid = [
+  [ 'Lush Forest', 'Tropical Beach' ],
+  [ 'Chilly Tundra', 'Dry Desert' ],
+];
+
+let row = 0;
+let col = 0;
+let shouldQuit = false;
+
+command({
+  verb: 'go',
+  accept: [ Format.VO ],
+  func: async ({ object }) => {
+
+    switch(object) {
+      case 'north':
+        row--;
+        break;
+      case 'south':
+        row++;
+        break;
+      case 'east':
+        col++;
+        break;
+      case 'west':
+        col--;
+        break;
+      default:
+        console.log(`Cannot go ${object}`);
+        return CommandResult.FORMAT_ERROR;
+    }
+
+    if (row < 0) {
+      row = 0;
+    } else if (row > 1) {
+      row = 1;
+    }
+
+    if (col < 0) {
+      col = 0;
+    } else if (col > 1) {
+      col = 1;
+    }
+
+    console.log(`(${col}, ${row})`);
+
+    return CommandResult.HANDLED;
+  }
+});
+
+command({
+  verb: 'look',
+  accept: [ Format.V ],
+  func: async () => {
+    console.log(grid[row][col]);
+    return CommandResult.HANDLED;
+  }
+});
+
+command({
+  verb: 'quit',
+  accept: [ Format.V ],
+  func: async () => {
+    console.log('Goodbye...');
+    shouldQuit = true;
+    return CommandResult.HANDLED;
+  }
+});
+
+async function getCommand() {
+  return new Promise(resolve => {
+    rl.question('> ', cmd => {
+      resolve(cmd);
+    });
+  });
+}
+
+async function main() {
+  while (!shouldQuit) {
+    const command = await getCommand();
+    let result = await processText(command);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log('Come again?');
+    }
+  }
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "directo",
   "version": "0.0.1",
   "description": "A command parsing library for RPGs",
-  "main": "index.js",
+  "main": "src/index.js",
   "scripts": {
     "test": "jest",
     "lint:js": "eslint src/"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     }
   },
   "dependencies": {
-    "eslint-plugin-node": "11.0.0"
+    "eslint-plugin-node": "11.0.0",
+    "joi": "14.3.1"
   }
 }

--- a/src/directo.js
+++ b/src/directo.js
@@ -1,0 +1,66 @@
+const Joi = require('joi');
+const { Format, CommandResult } = require('./enums');
+const { classify } = require('./parser');
+
+const commandSchema = Joi.object({
+  verb: Joi.alternatives([Joi.string(), Joi.array().items(Joi.string())]).required(),
+  accept: Joi.array().items(Joi.string().valid(Object.values(Format))).min(1).optional(),
+  func: Joi.func().required()
+});
+
+class Directo {
+  constructor() {
+    this.commands = {};
+  }
+
+  /**
+   * Adds a new command to the command set.
+   * Throws if the command is invalid or has a conflicting verb.
+   */
+  addCommand(command) {
+    const { error } = Joi.validate(command, commandSchema);
+    if (error) {
+      throw error;
+    }
+
+    // Normalize to array for single item
+    if (typeof(command.verb) === 'string') {
+      command.verb = [ command.verb ];
+    }
+
+    if (Object.keys(this.commands).some(v => command.verb.includes(v))) {
+      throw new Error(`Duplicate verb ${command.verb}`);
+    }
+
+    for (const verb of command.verb) {
+      this.commands[verb.toLowerCase()] = command;
+    }
+  }
+
+  /**
+   * Asynchronously processes the input string and returns the result.
+   */
+  async processText(input, context) {
+    const parseResult = classify(input);
+    if (!parseResult.classified) {
+      return CommandResult.FORMAT_ERROR;
+    }
+
+    const command = this.commands[parseResult.verb.toLowerCase()];
+    if (!command) {
+      return CommandResult.UNHANDLED;
+    }
+
+    if (command.accept && !command.accept.includes(parseResult.format)) {
+      return CommandResult.FORMAT_ERROR;
+    }
+
+    parseResult.context = context;
+
+    return await command.func(parseResult);
+  }
+}
+
+module.exports = {
+  Directo
+};

--- a/src/enums.js
+++ b/src/enums.js
@@ -1,0 +1,56 @@
+/**
+ * An english preposition
+ */
+const Preposition = {
+  ABOVE: 'ABOVE',
+  ACROSS: 'ACROSS',
+  AFTER: 'AFTER',
+  AT: 'AT',
+  AROUND: 'AROUND',
+  BEFORE: 'BEFORE',
+  BEHIND: 'BEHIND',
+  BELOW: 'BELOW',
+  BESIDE: 'BESIDE',
+  BETWEEN: 'BETWEEN',
+  BY: 'BY',
+  DOWN: 'DOWN',
+  DURING: 'DURING',
+  FOR: 'FOR',
+  FROM: 'FROM',
+  IN: 'IN',
+  INSIDE: 'INSIDE',
+  ONTO: 'ONTO',
+  OF: 'OF',
+  OFF: 'OFF',
+  ON: 'ON',
+  OUT: 'OUT',
+  THROUGH: 'THROUGH',
+  TO: 'TO',
+  UNDER: 'UNDER',
+  UP: 'UP',
+  WITH: 'WITH'
+};
+
+/**
+ * An english determiner
+ * Note: Does not include quantifiers
+ */
+const Determiner = {
+  THE: 'THE',
+  THIS: 'THIS',
+  THAT: 'THAT',
+  THESE: 'THESE',
+  THOSE: 'THOSE',
+  MY: 'MY',
+  HIS: 'HIS',
+  HER: 'HER',
+  ITS: 'ITS',
+  OUR: 'OUR',
+  THEIR: 'THEIR',
+  ANOTHER: 'ANOTHER'
+};
+
+module.exports = {
+  Preposition,
+  Determiner
+}

--- a/src/enums.js
+++ b/src/enums.js
@@ -1,4 +1,34 @@
 /**
+ * Structure of an imperative sentence.
+ */
+const Format = {
+  /** Verb-only command */
+  V: 'V',
+  /** Verb followed by an object */
+  VO: 'VO',
+  /** verb, preposition, object */
+  VPO: 'VPO',
+  /** verb, object, preposition, subject */
+  VOPS: 'VOPS',
+  /** verb, determiner, object */
+  VDO: 'VDO',
+  /** verb, subject, determiner, object */
+  VSDO: 'VSDO'
+};
+
+/**
+ * The outcome of processTexting a block of text.
+ */
+const CommandResult = {
+  /** The command exists, but was not properly formatted. */
+  FORMAT_ERROR: 'FORMAT_ERROR',
+  /** The command was successfully handled. */
+  HANDLED: 'HANDLED',
+  /** Found nothing to do with the provided text. */
+  UNHANDLED: 'UNHANDLED',
+};
+
+/**
  * An english preposition
  */
 const Preposition = {
@@ -51,6 +81,8 @@ const Determiner = {
 };
 
 module.exports = {
+  Format,
+  CommandResult,
   Preposition,
   Determiner
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,28 @@
-/**
- * Returns true.
- */
-const retTrue = () => true;
+const { Format, CommandResult } = require('./enums');
+const { Directo } = require('./directo');
+
+let instance;
+
+function maybeInit() {
+  if (!instance) {
+    instance = new Directo();
+  }
+}
+
+function command(cmd) {
+  maybeInit();
+  instance.addCommand(cmd);
+}
+
+async function processText(input, context) {
+  maybeInit();
+  return await instance.processText(input, context);
+}
 
 module.exports = {
-  retTrue
+  Directo,
+  Format,
+  CommandResult,
+  command,
+  processText
 };

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,0 +1,87 @@
+const { Format, Preposition, Determiner } = require('./enums');
+
+const ALL_PREPOSITIONS = Object.values(Preposition);
+const ALL_DETERMINERS = Object.values(Determiner);
+
+function tokenize(text) {
+  return text.split(' ').filter(x => x !== '');
+}
+
+function classify(text) {
+  if (!text) {
+    return {
+      classified: false
+    };
+  }
+
+  let tokens = tokenize(text);
+  const verb = tokens[0];
+  tokens = tokens.slice(1);
+
+  if (tokens.length === 0) {
+    return {
+      classified: true,
+      format: Format.V,
+      verb
+    };
+  }
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (ALL_PREPOSITIONS.includes(token.toUpperCase())) {
+      if (i === 0) {
+        return {
+          classified: true,
+          format: Format.VPO,
+          verb,
+          preposition: token,
+          object: tokens.slice(i + 1).join(' ')
+        };
+      } else {
+        return {
+          classified: true,
+          format: Format.VOPS,
+          verb,
+          object: tokens.slice(0, i).join(' '),
+          preposition: token,
+          subject: tokens.slice(i + 1).join(' ')
+        };
+      }
+    }
+  }
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+    if (ALL_DETERMINERS.includes(token.toUpperCase())) {
+      if (i === 0) {
+        return {
+          classified: true,
+          format: Format.VDO,
+          verb,
+          determiner: token,
+          object: tokens.slice(i + 1).join(' ')
+        };
+      } else {
+        return {
+          classified: true,
+          format: Format.VSDO,
+          verb,
+          subject: tokens.slice(0, i).join(' '),
+          determiner: token,
+          object: tokens.slice(i + 1).join(' ')
+        };
+      }
+    }
+  }
+
+  return {
+    classified: true,
+    format: Format.VO,
+    verb,
+    object: tokens.join(' ')
+  };
+}
+
+module.exports = {
+  classify
+};

--- a/src/test/directo.test.js
+++ b/src/test/directo.test.js
@@ -1,5 +1,101 @@
-const { retTrue } = require('../');
+const { Format, CommandResult } = require('../enums');
+const { Directo } = require('../directo');
 
-test('some placeholder test', () => {
-  expect(retTrue()).toBe(true);
+function badCommand(command) {
+  return () => {
+    expect(() => {
+      const d = new Directo();
+      d.addCommand(command);
+    }).toThrow();
+  }
+}
+
+function goodCommand(command) {
+  return () => {
+    const d = new Directo();
+    d.addCommand(command);
+  }
+}
+
+it('rejects missing verb',     badCommand({ }));
+it('rejects malformed verb',   badCommand({ verb: 1 }));
+it('rejects missing func',     badCommand({ verb: 'it' }));
+it('rejects malformed func',   badCommand({ verb: [ 'it' ], func: 1 }));
+it('rejects malformed accept', badCommand({ verb: 'it', accept: 2, func() { } }));
+it('rejects uknown accept',    badCommand({ verb: 'it', accept: [ 'uuuh, what' ], func() { } }));
+it('accepts empty accept',     badCommand({ verb: ['go', 'walk' ], accept: [], func() { } }));
+
+it('accepts single verb',      goodCommand({ verb: 'it', func() { } }));
+it('accepts many verbs',       goodCommand({ verb: ['go', 'walk' ], func() { } }));
+it('accepts valid format',     goodCommand({ verb: ['go', 'walk' ], accept: [ Format.V ], func() { } }));
+it('accepts multiple formats', goodCommand({ verb: ['go', 'walk' ], accept: [ Format.V, Format.VO ], func() { } }));
+
+it('rejets commands with duplicate verbs', () => {
+  const d = new Directo();
+  d.addCommand({ verb: ['it', 'go'], func() { } });
+
+  expect(() => {
+    d.addCommand({ verb: 'go', func() { } });
+  }).toThrow();
+});
+
+it('handles basic text processing', async () => {
+  const d = new Directo();
+  let calledEat = false;
+  let calledWalk = false;
+
+  d.addCommand({
+    verb: 'eat',
+    async func() { calledEat = true; }
+  });
+
+  d.addCommand({
+    verb: 'walk',
+    async func() { calledWalk = true; }
+  });
+
+  await d.processText('eat something');
+  expect(calledEat).toBe(true);
+  expect(calledWalk).toBe(false);
+});
+
+it('respects accept', async () => {
+  const d = new Directo();
+  let eatCount = 0;
+
+  d.addCommand({
+    verb: 'eat',
+    accept: [ Format.VO ],
+    async func() { eatCount++; }
+  });
+
+  await d.processText('eat something');
+  await d.processText('eat something else');
+  const result = await d.processText('eat the food');
+
+  expect(eatCount).toBe(2);
+  expect(result).toBe(CommandResult.FORMAT_ERROR);
+});
+
+it('returns error for unrecognized verb', async () => {
+  const d = new Directo();
+  const result = await d.processText('get lamp');
+  expect(result).toBe(CommandResult.UNHANDLED);
+});
+
+it('passes along context when processing', async () => {
+  const d = new Directo();
+  let calledFunc = false;
+  let testContext = { name: 'bob', age: 12 };
+
+  d.addCommand({
+    verb: 'go',
+    async func({ context }) {
+      calledFunc = true;
+      expect(context).toEqual(testContext);
+    }
+  });
+
+  await d.processText('go', testContext);
+  expect(calledFunc).toBe(true);
 });

--- a/src/test/parser.test.js
+++ b/src/test/parser.test.js
@@ -1,0 +1,133 @@
+const { Format } = require('../enums');
+const { classify } = require('../parser');
+
+[
+  {
+    description: 'rejects empty string',
+    input: '',
+    expected: {
+      classified: false
+    }
+  },
+  {
+    description: 'rejects null string',
+    input: null,
+    expected: {
+      classified: false
+    }
+  },
+  {
+    description: 'rejects undefined string',
+    input: undefined,
+    expected: {
+      classified: false
+    }
+  },
+  {
+    description: 'parses basic V',
+    input: 'do',
+    expected: {
+      classified: true,
+      format: Format.V,
+      verb: 'do'
+    }
+  },
+  {
+    description: 'parses basic VO',
+    input: 'go north',
+    expected: {
+      classified: true,
+      format: Format.VO,
+      verb: 'go',
+      object: 'north'
+    }
+  },
+  {
+    description: 'parses basic VPO',
+    input: 'put on hat',
+    expected: {
+      classified: true,
+      format: Format.VPO,
+      verb: 'put',
+      preposition: 'on',
+      object: 'hat'
+    }
+  },
+  {
+    // We may one day want a VPDO format, but this documents
+    // how the parser behaves for now.
+    description: 'parses trickier VPO',
+    input: 'put on the hat',
+    expected: {
+      classified: true,
+      format: Format.VPO,
+      verb: 'put',
+      preposition: 'on',
+      object: 'the hat'
+    }
+  },
+  {
+    description: 'parses basic VOPS',
+    input: 'give sword to steve',
+    expected: {
+      classified: true,
+      format: Format.VOPS,
+      verb: 'give',
+      object: 'sword',
+      preposition: 'to',
+      subject: 'steve'
+    },
+  },
+  {
+    // May eventually want a VDOPS format for quantifiers
+    description: 'parses trickier VOPS',
+    input: 'give the sword to steve',
+    expected: {
+      classified: true,
+      format: Format.VOPS,
+      verb: 'give',
+      object: 'the sword',
+      preposition: 'to',
+      subject: 'steve'
+    },
+  },
+  {
+    description: 'parses basic VDO',
+    input: 'eat the cake',
+    expected: {
+      classified: true,
+      format: Format.VDO,
+      verb: 'eat',
+      determiner: 'the',
+      object: 'cake',
+    },
+  },
+  {
+    description: 'parses basic VSDO',
+    input: 'give steve the cookie',
+    expected: {
+      classified: true,
+      format: Format.VSDO,
+      verb: 'give',
+      subject: 'steve',
+      determiner: 'the',
+      object: 'cookie',
+    },
+  },
+  {
+    description: 'parses trickier VSDO',
+    input: 'give fair lady stevie my undying devotion',
+    expected: {
+      classified: true,
+      format: Format.VSDO,
+      verb: 'give',
+      subject: 'fair lady stevie',
+      determiner: 'my',
+      object: 'undying devotion',
+    },
+  }
+].forEach(testCase => {
+  it(testCase.description, () => {
+    expect(classify(testCase.input)).toEqual(testCase.expected);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1714,6 +1714,11 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
+hoek@6.x.x:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.3.tgz#73b7d33952e01fe27a38b0457294b79dd8da242c"
+  integrity sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ==
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
@@ -2010,6 +2015,13 @@ isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
+isemail@3.x.x:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.2.0.tgz#59310a021931a9fb06bbb51e155ce0b3f236832c"
+  integrity sha512-zKqkK+O+dGqevc93KNsbZ/TqTUFd46MwWjYOoMrjIMZ51eU7DtQG3Wmd9SQQT7i7RVnuTPEiYEWHU3MSbxC1Tg==
+  dependencies:
+    punycode "2.x.x"
 
 isexe@^2.0.0:
   version "2.0.0"
@@ -2424,6 +2436,15 @@ jest@25.1.0:
     "@jest/core" "^25.1.0"
     import-local "^3.0.2"
     jest-cli "^25.1.0"
+
+joi@14.3.1:
+  version "14.3.1"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-14.3.1.tgz#164a262ec0b855466e0c35eea2a885ae8b6c703c"
+  integrity sha512-LQDdM+pkOrpAn4Lp+neNIFV3axv1Vna3j38bisbQhETPMANYRbFJFUyOZcOClYvM/hppMhGWuKSFEK9vjrB+bQ==
+  dependencies:
+    hoek "6.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -3054,7 +3075,7 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@2.x.x, punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -3690,6 +3711,13 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
+
+topo@3.x.x:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.3.tgz#d5a67fb2e69307ebeeb08402ec2a2a6f5f7ad95c"
+  integrity sha512-IgpPtvD4kjrJ7CRA3ov2FhWQADwv+Tdqbsf1ZnPUSAtCJ9e1Z44MmoSGDXGk4IppoZA7jd/QRkNddlLJWlUZsQ==
+  dependencies:
+    hoek "6.x.x"
 
 tough-cookie@^2.3.3, tough-cookie@~2.5.0:
   version "2.5.0"


### PR DESCRIPTION
![directo-demo](https://user-images.githubusercontent.com/8814659/77240099-68862e00-6bb8-11ea-997e-d48517c2fd73.gif)

This adds initial interface stuff for `directo`. Architectural/usage details should be found in the README and demos.

Things I want to do later:
1. Account for quantifiers (help the consumer understand things like `give fred three apples`)
2. Middleware (for example, swap out known subject and object strings for ID or refs)
