### PR TITLE
Accept quantifying determiners

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Jest Tests",
+            "type": "node",
+            "request": "launch",
+            "disableOptimisticBPs": true,
+            "runtimeArgs": [
+              "--inspect-brk",
+              "${workspaceRoot}/node_modules/.bin/jest",
+              "--runInBand"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "port": 9229
+        },
+        {
+            "name": "Debug Jest Tests (windows)",
+            "type": "node",
+            "request": "launch",
+            "disableOptimisticBPs": true,
+            "runtimeArgs": [
+              "--inspect-brk",
+              "${workspaceRoot}/node_modules/jest/bin/jest.js",
+              "--runInBand"
+            ],
+            "console": "integratedTerminal",
+            "internalConsoleOptions": "neverOpen",
+            "port": 9229
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -235,3 +235,56 @@ Prints
 ```none
 Bob went west
 ```
+
+## Quantifying Determiners
+
+Any command format that expects a determiner can also handle quantities. In that case, a `quantity` field will be included in the callback object.
+
+```javascript
+const { command, processText, Format, CommandResult } = require('../src');
+
+command({
+  verb: 'add',
+  accept: [ Format.VDO ],
+  func: async ({ context, quantity }) => {
+    context.total += quantity;
+  }
+});
+
+command({
+  verb: 'subtract',
+  accept: [ Format.VDO ],
+  func: async ({ context, quantity }) => {
+    context.total -= quantity;
+  }
+});
+
+command({
+  verb: 'print',
+  func: async ({ context }) => {
+    console.log(`${context.total} bananas`)
+  }
+});
+
+const context = { total: 0 };
+
+(async (commands) => {
+  for (const command of commands) {
+    const result = await processText(command, context);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log(`Did not understand '${c}'`);
+    }
+  }
+})([
+  'add 5 bananas',
+  'subtract 2 bananas',
+  'add 4 bananas',
+  'print',
+]);
+```
+
+Prints
+
+```none
+7 bananas
+```

--- a/demo/demo3.js
+++ b/demo/demo3.js
@@ -1,0 +1,40 @@
+const { command, processText, Format, CommandResult } = require('../src');
+
+command({
+  verb: 'add',
+  accept: [ Format.VDO ],
+  func: async ({ context, quantity }) => {
+    context.total += quantity;
+  }
+});
+
+command({
+  verb: 'subtract',
+  accept: [ Format.VDO ],
+  func: async ({ context, quantity }) => {
+    context.total -= quantity;
+  }
+});
+
+command({
+  verb: 'print',
+  func: async ({ context }) => {
+    console.log(`${context.total} bananas`)
+  }
+});
+
+const context = { total: 0 };
+
+(async (commands) => {
+  for (const command of commands) {
+    const result = await processText(command, context);
+    if (result === CommandResult.FORMAT_ERROR) {
+      console.log(`Did not understand '${c}'`);
+    }
+  }
+})([
+  'add 5 bananas',
+  'subtract 2 bananas',
+  'add 4 bananas',
+  'print',
+]);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.1",
   "description": "A command parsing library for RPGs",
   "main": "src/index.js",
+  "engines": {
+    "node": "^12.14.0",
+    "npm": "^6.13.4"
+  },
   "scripts": {
     "test": "jest",
     "lint:js": "eslint src/"

--- a/src/enums.js
+++ b/src/enums.js
@@ -80,9 +80,56 @@ const Determiner = {
   ANOTHER: 'ANOTHER'
 };
 
+const NonNumericSingulars = {
+  A: 1,
+  AN: 1
+}
+
+const Digits = {
+  ZERO: 0,
+  ONE: 1,
+  TWO: 2,
+  THREE: 3,
+  FOUR: 4,
+  FIVE: 5,
+  SIX: 6,
+  SEVEN: 7,
+  EIGHT: 8,
+  NINE: 9,
+};
+
+const BaseNumbers = {
+  ...NonNumericSingulars,
+  ...Digits,
+  TEN: 10,
+  ELEVEN: 11,
+  TWELVE: 12,
+  THIRTEEN: 13,
+  FOURTEEN: 14,
+  FIFTEEN: 15,
+  SIXTEEN: 16,
+  SEVENTEEN: 17,
+  EIGHTEEN: 18,
+  NINETEEN: 19
+};
+
+const TensNumbers = {
+  TWENTY: 20,
+  THIRTY: 30,
+  FORTY: 40,
+  FIFTY: 50,
+  SIXTY: 60,
+  SEVENTY: 70,
+  EIGHTY: 80,
+  NINETY: 90
+};
+
 module.exports = {
   Format,
   CommandResult,
   Preposition,
-  Determiner
+  Determiner,
+  BaseNumbers,
+  Digits,
+  TensNumbers
 }

--- a/src/test/parser.test.js
+++ b/src/test/parser.test.js
@@ -1,5 +1,5 @@
 const { Format } = require('../enums');
-const { classify } = require('../parser');
+const { classify, tryParseNumber } = require('../parser');
 
 [
   {
@@ -100,6 +100,7 @@ const { classify } = require('../parser');
       verb: 'eat',
       determiner: 'the',
       object: 'cake',
+      quantity: 1
     },
   },
   {
@@ -112,6 +113,7 @@ const { classify } = require('../parser');
       subject: 'steve',
       determiner: 'the',
       object: 'cookie',
+      quantity: 1
     },
   },
   {
@@ -124,10 +126,85 @@ const { classify } = require('../parser');
       subject: 'fair lady stevie',
       determiner: 'my',
       object: 'undying devotion',
+      quantity: 1
+    },
+  },
+  {
+    description: 'picks up on articles as quantifying determiners',
+    input: 'give fred a hug',
+    expected: {
+      classified: true,
+      format: Format.VSDO,
+      verb: 'give',
+      subject: 'fred',
+      determiner: 'a',
+      quantity: 1,
+      object: 'hug',
+    },
+  },
+  {
+    description: 'picks up on numbers as quantifying determiners',
+    input: 'give fred seventy-five hugs',
+    expected: {
+      classified: true,
+      format: Format.VSDO,
+      verb: 'give',
+      subject: 'fred',
+      determiner: 'seventy-five',
+      quantity: 75,
+      object: 'hugs',
+    },
+  },
+  {
+    description: 'picks up on numerals as quantifying determiners',
+    input: 'give fred 10,975.2 hugs',
+    expected: {
+      classified: true,
+      format: Format.VSDO,
+      verb: 'give',
+      subject: 'fred',
+      determiner: '10,975.2',
+      quantity: 10975.2,
+      object: 'hugs',
     },
   }
 ].forEach(testCase => {
   it(testCase.description, () => {
     expect(classify(testCase.input)).toEqual(testCase.expected);
+  });
+});
+
+[
+  {
+    input: '1',
+    expected: 1
+  },
+  {
+    input: 'two',
+    expected: 2
+  },
+  {
+    input: 'three',
+    expected: 3
+  },
+  {
+    input: 'fifty-five',
+    expected: 55
+  },
+  {
+    input: 'ninety-four',
+    expected: 94
+  },
+  {
+    input: '1,237,564.25',
+    expected: 1237564.25
+  },
+  {
+    input: 'flarbendugal',
+    expected: undefined
+  }
+].forEach(testCase => {
+  it('parses numbers or returns undefined', () => {
+    expect(tryParseNumber(testCase.input)).toEqual(testCase.expected);
   });
 });


### PR DESCRIPTION
# What's New?

This includes numbers as well as `a` and `an` when searching for determiners in a command. If a specific quantity is found, it is included in the classification structure. I originally had some more-grandiose ideas for this, which have been abandoned but saved in `feature/wip-english-numbers` in case we ever decide to pick back up on it. For now, numeric input is limited to numbers that may be represented in a single token.